### PR TITLE
Port the location_cck module to allow for Location fields to be used.

### DIFF
--- a/contrib/location_cck/location_cck.info
+++ b/contrib/location_cck/location_cck.info
@@ -2,4 +2,5 @@ name = Location CCK
 description = Defines a Location field type.
 dependencies[] = location
 package = Fields
-core = 7.x
+backdrop = 1.x
+type = module

--- a/contrib/location_cck/location_cck.install
+++ b/contrib/location_cck/location_cck.install
@@ -6,43 +6,8 @@
  */
 
 /**
- * Drupal 6 location_cck 3.x update.
+ * Implements hook_update_last_removed().
  */
-function location_cck_update_6301() {
-  // Create a temporary table to fix some location_instance data.
-  $schema = drupal_get_schema('location_instance');
-  $schema['description'] = 'Temp table to repair data integrity of location_instance table.';
-  unset($schema['indexes']);
-  db_create_table('location_instance_tmp', $schema);
-
-  // Populate the temporary table.
-  $join_select = db_select('location_instance', 'li');
-  $join_select->addExpression("SUBSTRING_INDEX(genid, ':', -1)", 'genvid');
-  $join_select->fields('li', array('lid', 'genid'));
-
-  $insert_select = db_select('node', 'n')
-    ->fields('n', array('nid', 'vid'))
-    ->fields('l', array('genid', 'lid'));
-  $insert_select->join($join_select, 'l', 'n.vid = l.genvid');
-
-  db_insert('location_instance_tmp')
-    ->fields(array('nid', 'vid', 'genid', 'lid'))
-    ->from($insert_select)
-    ->execute();
-
-  // Update the location_instance table.
-  db_delete('location_instance')
-    ->condition('genid', 'cck:%', 'LIKE')
-    ->execute();
-
-  $insert_select = db_select('location_instance_tmp', 'lit')
-    ->fields('lit', array('nid', 'vid', 'genid', 'lid'));
-
-  db_insert('location_instance')
-    ->fields(array('nid', 'vid', 'genid', 'lid'))
-    ->from($insert_select)
-    ->execute();
-
-  // Remove the temporary table.
-  db_drop_table('location_instance_tmp');
+function location_cck_update_last_removed() {
+  return 6301;
 }

--- a/contrib/location_cck/location_cck.module
+++ b/contrib/location_cck/location_cck.module
@@ -428,7 +428,7 @@ function location_cck_field_widget_form(&$form, &$form_state, $field, $instance,
   if ($field['type'] == 'location') {
     $settings = isset($field['settings']['location_settings']) ? $field['settings']['location_settings'] : array();
     if (isset($form_state['values'])) {
-      $form_state_field_values = drupal_array_get_nested_value($form_state['values'], $element['#field_parents']);
+      $form_state_field_values = backdrop_array_get_nested_value($form_state['values'], $element['#field_parents']);
     }
 
     // Load location data for existing locations.
@@ -562,7 +562,7 @@ function theme_location_cck_field_map($variables) {
       '#type' => 'gmap',
       '#gmap_settings' => $map,
     );
-    $content = drupal_render($location_map);
+    $content = backdrop_render($location_map);
   }
 
   return $content;


### PR DESCRIPTION
Fixes #5 

This module is required for any Location type fields to be able to be used in Backdrop.